### PR TITLE
Bug Fix: discard final ROI if signal doesnt drop below threshold

### DIFF
--- a/cardiopy/ekg.py
+++ b/cardiopy/ekg.py
@@ -5,19 +5,19 @@
     NaN data can be accounted for by removing false IBIs with rm_ibi method.
 
     TO DO:
-    	** Update docstrings **
+        ** Update docstrings **
         1. Add option to extract sampling frequency & milliseconds from time column
         2. Re-add code to import previously cleaned nn data -- DONE. 11-24-19 in hrv_stats method
         3. Add range options for indices for rm peaks and rm ibis
         4. Add more descriptive error message for ValueError encountered during
-        	add_peaks if range is outside of data
+            add_peaks if range is outside of data
         5. Add option for auto-determining threshold parameters (mw_size and upshift)
         6. Add threshold statistics (sensitivity & PPV) to output
         7. Update hrv_stats to assume NN
         8. Add nn attribute for data that doesn't require cleanings
         9. Fix spreadsheet alignment when smoothing used (incorp smooth & sm_wn metadata to all files)
         10. Option for 1000Hz interpolation prior to peak detection; Option for 4Hz resampling of NN tachogram
-        	rather than original sampling frequencys
+            rather than original sampling frequencys
 
 """
 
@@ -202,12 +202,20 @@ class EKG:
                 roi_start = x
                 # count forwards to find down-crossing
                 for h in range(x, len(raw), 1):
+                    # if value drops below threshold, end ROI
                     if raw[h] < thres[h]:
                         roi_end = h
                         break
-                # get maximum between roi_start and roi_end
-                peak = raw[x:h].idxmax()
-                peaks.append(peak)
+                    # else if data ends before dropping below threshold, leave ROI open
+                    # & advance h pointer to end loop
+                    elif (raw[h] >= thres[h]) and (h == len(raw)-1):
+                        roi_end = None
+                        h += 1
+                        break
+                # if ROI is closed, get maximum between roi_start and roi_end
+                if roi_end:
+                    peak = raw[x:h].idxmax()
+                    peaks.append(peak)
                 # advance the pointer
                 x = h
             else:
@@ -1033,7 +1041,7 @@ class EKG:
 
 
     ## plotting methods ##
-	def plotpeaks(self, rpeaks=True, ibi=True):
+    def plotpeaks(self, rpeaks=True, ibi=True):
         """ plot EKG class instance """
         # set number of panels
         if ibi == True:


### PR DESCRIPTION
additional clause in detect_Rpeaks to leave ROI open and discard if pointer is at the end of the data & still above detection threshold