### PR TITLE
Rm peaks docstrings

### DIFF
--- a/cardiopy/ekg.py
+++ b/cardiopy/ekg.py
@@ -242,12 +242,13 @@ class EKG:
         Parameters
         ----------
         time: str {'hh:mm:ss'}
-        Time in the format specified dictating the second containing the peak of interest.
+            Time in the format specified dictating the second containing the peak of interest.
         
-        Returns
+        Modifies
         -------
-        Modified self.rpeaks and self.rpeaks_df attributes. Removed peaks added to 
-        self.rpeak_artifacts attribute.
+        self.rpeaks : peaks that have been removed are removed
+        self.rpeaks_df : peaks that have been removed are removed
+        self.rpeak_artifacts : removed peaks added
         """
         
         # print all rpeaks in the second of interest

--- a/cardiopy/ekg.py
+++ b/cardiopy/ekg.py
@@ -246,9 +246,9 @@ class EKG:
         
         Modifies
         -------
-        self.rpeaks : peaks that have been removed are removed
-        self.rpeaks_df : peaks that have been removed are removed
-        self.rpeak_artifacts : removed peaks added
+        self.rpeaks : Peaks that have been removed are removed from attribute.
+        self.rpeaks_df : Peaks that have been removed are removed from attribute.
+        self.rpeak_artifacts : Removed peaks added to attribute.
         """
         
         # print all rpeaks in the second of interest

--- a/cardiopy/ekg.py
+++ b/cardiopy/ekg.py
@@ -237,11 +237,12 @@ class EKG:
 
     def rm_peaks(self, time):
         """ 
-        Examine a second of interest and manually remove artifact peaks
+        Examine a second of interest and manually remove artifact R peaks.
         
         Parameters
         ----------
-        time: str format 'hh:mm:ss'
+        time: str {'hh:mm:ss'}
+        Time in the format specified dictating the second containing the peak of interest.
         
         Returns
         -------


### PR DESCRIPTION
docstrings for rm peaks method.
Included a modifies section for the attributes modified.
Have not changed the name rm peaks to rm peak because this must be done across several methods (many reference remove peaks in their documentation). will do all at once in seperate PR. 