### PR TITLE
fixing installation and updating changes.txt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,3 @@
 v0.0.1, 9-21-2019 -- Initial Release
+v0.0.2, 7-20-2020 -- Updated setup.py to reflect the BSD-3 Clause license
+v0.0.3, 7-27-2020 -- Updated setup.py to fix installation bug

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r") as fh:
 	long_description = fh.read()
 
 setuptools.setup(
-	name = 'CardioPy',
-	version = "0.0.2",
+	name = 'cardiopy',
+	version = "0.0.3",
 	author = "Jackie Gottshall",
 	author_email = "jackie.gottshall@gmail.com",
 	description = "Analysis package for single-lead clinical EKG data",
@@ -24,7 +24,6 @@ setuptools.setup(
 	install_requires = [
 		"datetime",
 		"matplotlib",
-		"os",
 		"pandas",
 		"scipy",
 		"statistics",


### PR DESCRIPTION
Installation from pypi didn't work because os was being installed in addition to within python (so twice) and was throwing an error. Removed os from install_requires within setup.py and updated changes.txt to reflect new versions. (Put the date as monday so there is time for PRs to be accepted) Changes cardiopy to lowercase to stay with convention.